### PR TITLE
validity checks for Warden.SetOwner

### DIFF
--- a/lua/warden/warden.lua
+++ b/lua/warden/warden.lua
@@ -137,6 +137,10 @@ if SERVER then
 	Warden.Players = Warden.Players or {}
 
 	function Warden.SetOwner(ent, ply)
+		if not IsValid(ent) or not IsValid(ply) then
+			return
+		end
+
 		local index = ent:EntIndex()
 		local steamid = ply:SteamID()
 


### PR DESCRIPTION
This function can sometimes be called in contexts where `ent` doesn't actually exist. The `ply` check is for extra safety.